### PR TITLE
Fix alexnet.csv not found error

### DIFF
--- a/scale.py
+++ b/scale.py
@@ -8,7 +8,7 @@ from absl import app
 FLAGS = flags.FLAGS
 #name of flag | default | explanation
 flags.DEFINE_string("arch_config","./configs/scale.cfg","file where we are getting our architechture from")
-flags.DEFINE_string("network","./topologies/alexnet.csv","topology that we are reading")
+flags.DEFINE_string("network","./topologies/conv_nets/alexnet.csv","topology that we are reading")
 
 
 class scale:


### PR DESCRIPTION
==============================

The alexnet.csv file is in the /topologies/conv_nets path. But In the
code the the vallue of the `network` flag is: 'topologies/alexnet.csv'
.
Because of this incorrect path, when you ru scale.py file, you will get
following error:
	param_file = open(topology_file, 'r')
	FileNotFoundError: [Errno 2] No such file or directory: './topologies/alexnet.csv'
I've fixed this problem by changing this path to the correct one.