### PR TITLE
Support separated stride_h and stride_w

### DIFF
--- a/run_nets.py
+++ b/run_nets.py
@@ -57,7 +57,7 @@ def run_net( ifmap_sram_size=1,
         #print(len(elems))
         
         # Do not continue if incomplete line
-        if len(elems) < 8:
+        if len(elems) < 9:
             continue
 
         name = elems[0]
@@ -73,10 +73,10 @@ def run_net( ifmap_sram_size=1,
         num_channels = int(elems[5])
         num_filters = int(elems[6])
 
-        if len(elems) == 9:
+        if len(elems) == 10:
             stride_h = int(elems[7])
             stride_w = int(elems[8])
-        elif len(elems) == 8:
+        elif len(elems) == 9:
             stride_h = int(elems[7])
             stride_w = int(elems[7])
 

--- a/run_nets.py
+++ b/run_nets.py
@@ -57,7 +57,7 @@ def run_net( ifmap_sram_size=1,
         #print(len(elems))
         
         # Do not continue if incomplete line
-        if len(elems) < 9:
+        if len(elems) < 8:
             continue
 
         name = elems[0]
@@ -73,8 +73,13 @@ def run_net( ifmap_sram_size=1,
         num_channels = int(elems[5])
         num_filters = int(elems[6])
 
-        strides = int(elems[7])
-        
+        if len(elems) == 9:
+            stride_h = int(elems[7])
+            stride_w = int(elems[8])
+        elif len(elems) == 8:
+            stride_h = int(elems[7])
+            stride_w = int(elems[7])
+
         ifmap_base  = offset_list[0]
         filter_base = offset_list[1]
         ofmap_base  = offset_list[2]
@@ -92,7 +97,8 @@ def run_net( ifmap_sram_size=1,
                                 filt_w = filt_w,
                                 num_channels = num_channels,
                                 num_filt = num_filters,
-                                strides = strides,
+                                stride_h = stride_h,
+                                stride_w = stride_w,
                                 data_flow = data_flow,
                                 word_size_bytes = 1,
                                 filter_sram_size = filter_sram_size,

--- a/sram_traffic_os.py
+++ b/sram_traffic_os.py
@@ -9,7 +9,8 @@ def sram_traffic(
         ifmap_h=7, ifmap_w=7,
         filt_h=3, filt_w=3,
         num_channels=3,
-        strides=1, num_filt=8,
+        stride_h=1, stride_w=1,
+        num_filt=8,
         ofmap_base=2000000, filt_base=1000000, ifmap_base=0,
         sram_read_trace_file="sram_read.csv",
         sram_write_trace_file="sram_write.csv"
@@ -17,8 +18,8 @@ def sram_traffic(
 
 
     # Dimensions of output feature map channel
-    E_h = (ifmap_h - filt_h + strides) / strides
-    E_w = (ifmap_w - filt_w + strides) / strides
+    E_h = math.floor((ifmap_h - filt_h + stride_h) / stride_h)
+    E_w = math.floor((ifmap_w - filt_w + stride_w) / stride_w)
     
     # Number of pixels in one convolution window
     px_per_conv_window = filt_h * filt_w * num_channels
@@ -43,7 +44,7 @@ def sram_traffic(
                             num_h_fold = int(num_h_fold),
                             ifmap_h = ifmap_h, ifmap_w= ifmap_w,
                             filt_h= filt_h, filt_w= filt_w,
-                            num_channels= num_channels, stride=strides,
+                            num_channels= num_channels, stride_h=stride_h, stride_w=stride_w,
                             ofmap_h= int(E_h), ofmap_w= int(E_w), num_filters = num_filt,
                             filt_base= filt_base, ifmap_base= ifmap_base,
                             sram_read_trace_file= sram_read_trace_file
@@ -76,7 +77,7 @@ def gen_read_trace(
         num_h_fold = 1,
         ifmap_h = 7, ifmap_w = 7,
         filt_h = 3, filt_w =3,
-        num_channels = 3, stride = 1,
+        num_channels = 3, stride_h = 1, stride_w=1,
         ofmap_h =5, ofmap_w = 5, num_filters = 8, 
         filt_base = 1000000, ifmap_base = 0,
         sram_read_trace_file = "sram_read.csv",
@@ -115,8 +116,8 @@ def gen_read_trace(
     # This initialization assumes num_rows << num_ofmap_px
     # The assignment logic needs to be modified if that is not the case
     for r in range(dim_rows):
-        base_row_id = math.floor(r / ofmap_w) * stride
-        base_col_id = r % ofmap_w * stride
+        base_row_id = math.floor(r / ofmap_w) * stride_h
+        base_col_id = r % ofmap_w * stride_w
         base_addr  = base_row_id * hc + base_col_id * num_channels 
 
         if r < e2:
@@ -195,8 +196,8 @@ def gen_read_trace(
                 if ofmap_idx < e2:
                     row_clk_offset[r] = 0
 
-                    base_row_id = math.floor(ofmap_idx / ofmap_w) * stride
-                    base_col_id = ofmap_idx % ofmap_w * stride
+                    base_row_id = math.floor(ofmap_idx / ofmap_w) * stride_h
+                    base_col_id = ofmap_idx % ofmap_w * stride_w
                     base_addr  = base_row_id * hc + base_col_id * num_channels
                     row_base_addr[r] = base_addr
 
@@ -207,8 +208,8 @@ def gen_read_trace(
                     if(v_fold_row[r] < num_v_fold):
                         row_ofmap_idx[r]  = r
 
-                        base_row_id = math.floor(r / ofmap_w) * stride
-                        base_col_id = r % ofmap_w * stride
+                        base_row_id = math.floor(r / ofmap_w) * stride_h
+                        base_col_id = r % ofmap_w * stride_w
                         base_addr  = base_row_id * hc + base_col_id * num_channels
                         row_base_addr[r]  = base_addr
 
@@ -425,6 +426,6 @@ if __name__ == "__main__":
        dimension_cols = 4,
        ifmap_h = 7, ifmap_w = 7,
        filt_h = 2, filt_w = 2,
-       num_channels = 1, strides = 1,
+       num_channels = 1, stride_h = 1, stride_w=1,
        num_filt = 7
    )

--- a/trace_gen_wrapper.py
+++ b/trace_gen_wrapper.py
@@ -10,7 +10,8 @@ def gen_all_traces(
         ifmap_h = 7, ifmap_w = 7,
         filt_h  = 3, filt_w = 3,
         num_channels = 3,
-        strides = 1, num_filt = 8,
+        stride_h = 1, stride_w = 1, 
+        num_filt = 8,
 
         data_flow = 'os',
 
@@ -38,7 +39,8 @@ def gen_all_traces(
                 ifmap_h=ifmap_h, ifmap_w=ifmap_w,
                 filt_h=filt_h, filt_w=filt_w,
                 num_channels=num_channels,
-                strides=strides, num_filt=num_filt,
+                stride_h=stride_h, stride_w = stride_w,
+                num_filt=num_filt,
                 filt_base=filt_base, ifmap_base=ifmap_base,
                 ofmap_base = ofmap_base,
                 sram_read_trace_file=sram_read_trace_file,
@@ -52,7 +54,8 @@ def gen_all_traces(
                 ifmap_h = ifmap_h, ifmap_w = ifmap_w,
                 filt_h = filt_h, filt_w = filt_w,
                 num_channels = num_channels,
-                strides = strides, num_filt = num_filt,
+                stride_h = stride_h, stride_w = stride_w,
+                num_filt = num_filt,
                 ofmap_base = ofmap_base, filt_base = filt_base, ifmap_base = ifmap_base,
                 sram_read_trace_file = sram_read_trace_file,
                 sram_write_trace_file = sram_write_trace_file
@@ -65,7 +68,8 @@ def gen_all_traces(
                 ifmap_h = ifmap_h, ifmap_w = ifmap_w,
                 filt_h = filt_h, filt_w = filt_w,
                 num_channels = num_channels,
-                strides = strides, num_filt = num_filt,
+                stride_h = stride_h, stride_w = stride_w,
+                num_filt = num_filt,
                 ofmap_base = ofmap_base, filt_base = filt_base, ifmap_base = ifmap_base,
                 sram_read_trace_file = sram_read_trace_file,
                 sram_write_trace_file = sram_write_trace_file
@@ -406,8 +410,7 @@ def test():
         array_w = dimensions,
         ifmap_h= ifmap_h, ifmap_w= ifmap_w, num_channels=num_channels,
         filt_h= filt_h, filt_w= filt_w, num_filt= num_filters,
-        strides= strides,
-
+        stride_h= strides, stride_w = strides,
         filter_sram_size= filter_sram_size, ifmap_sram_size= ifmap_sram_size, ofmap_sram_size= ofmap_sram_size,
         word_size_bytes= word_sz, filt_base= filter_base, ifmap_base= ifmap_base,
 


### PR DESCRIPTION
- Parameter 'strides' is now split in stride_h and stride_w (topo files with 'strides' param
are still accepted for compatibility).
- Fixed a bug in sram_traffic_is causing the filter_map to be read beyond the limits