### PR TITLE
fix bug for ifmap trace generation in ws

### DIFF
--- a/sram_traffic_ws.py
+++ b/sram_traffic_ws.py
@@ -379,8 +379,8 @@ def gen_trace_ifmap_partial(
     r2c = filt_h * filt_w * num_channels
     rc = filt_w * num_channels
     hc = ifmap_w * num_channels
-    E_w = (ifmap_w - filt_w + stride) / stride 
-    E_h = (ifmap_h - filt_h + stride) / stride 
+    E_w = math.floor((ifmap_w - filt_w + stride) / stride )
+    E_h = math.floor((ifmap_h - filt_h + stride) / stride )
 
     num_ofmap_px = E_h * E_w
     index = r2c - remaining


### PR DESCRIPTION
as long as E_w is not integer, the orignal code generates wrong trace by not increasing the row index (https://github.com/ARM-software/SCALE-Sim/blob/5825f6cee26bac223ce6019fcfc4f384c1142cb6/sram_traffic_ws.py#L441)